### PR TITLE
Feature/커뮤니티 게시글 삭제 구현 완료

### DIFF
--- a/src/main/java/inq/upfit/config/DataLoader.java
+++ b/src/main/java/inq/upfit/config/DataLoader.java
@@ -1,0 +1,35 @@
+package inq.upfit.config;
+
+import inq.upfit.domain.master.Department;
+import inq.upfit.repository.DepartmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/** (테스트용)
+ * 애플리케이션 시작 시점에 초기 데이터를 생성하는 클래스입니다.
+ * CommandLineRunner 인터페이스를 구현하여 run() 메서드에 로직을 작성합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataLoader implements CommandLineRunner {
+
+    private final DepartmentRepository departmentRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (departmentRepository.count() == 0) {
+            log.info("테스트용 부서 더미 데이터를 생성합니다...");
+            departmentRepository.save(new Department(null, "개발팀", null));
+            departmentRepository.save(new Department(null, "기획팀", null));
+            departmentRepository.save(new Department(null, "디자인팀", null));
+            departmentRepository.save(new Department(null, "마케팅팀", null));
+            log.info("부서 더미 데이터 생성이 완료되었습니다.");
+        } else {
+            log.info("이미 부서 데이터가 존재하므로 더미 데이터를 생성하지 않습니다.");
+        }
+    }
+}
+

--- a/src/main/java/inq/upfit/controller/PostController.java
+++ b/src/main/java/inq/upfit/controller/PostController.java
@@ -10,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -32,4 +29,15 @@ public class PostController {
         PostResponseDto newPostDto = postService.writePost(dto, userId);
         return new ResponseEntity<>(newPostDto, HttpStatus.CREATED);
     }
+
+    @DeleteMapping("/{postId}")
+        public ResponseEntity<Void> deletePost(
+                @PathVariable Long postId,
+                @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            // 서비스로 삭제 요청
+            postService.deletePost(postId, userDetails);
+
+            // 삭제 성공 시 204 No Content 반환
+            return ResponseEntity.noContent().build();
+        }
 }

--- a/src/main/java/inq/upfit/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inq/upfit/exception/GlobalExceptionHandler.java
@@ -71,6 +71,18 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(PostNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePostNotFound(PostNotFoundException e) {
+      ErrorResponse response = ErrorResponse.builder()
+              .status(HttpStatus.NOT_FOUND.value())
+              .error("NOT_FOUND")
+              .message(e.getMessage())
+              .timestamp(LocalDateTime.now())
+              .build();
+
+      return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
         log.error("예상하지 못한 오류 발생: ", e);

--- a/src/main/java/inq/upfit/exception/PostNotFoundException.java
+++ b/src/main/java/inq/upfit/exception/PostNotFoundException.java
@@ -1,0 +1,7 @@
+package inq.upfit.exception;
+
+public class PostNotFoundException extends RuntimeException {
+    public PostNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/inq/upfit/service/PostService.java
+++ b/src/main/java/inq/upfit/service/PostService.java
@@ -1,11 +1,13 @@
 package inq.upfit.service;
 
+import inq.upfit.auth.utils.UserDetailsImpl;
 import inq.upfit.domain.master.Post;
 import inq.upfit.domain.master.Department;
 import inq.upfit.domain.master.User;
 import inq.upfit.dto.PostResponseDto;
 import inq.upfit.dto.PostWriteRequestDto;
-import inq.upfit.exception.DepartmentNotFoundException;
+import inq.upfit.exception.PostNotFoundException;
+import inq.upfit.exception.UnauthorizedException;
 import inq.upfit.exception.UserNotFoundException;
 import inq.upfit.repository.DepartmentRepository;
 import inq.upfit.repository.PostRepository;
@@ -28,13 +30,31 @@ public class PostService {
         User writer = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("작성자를 찾을 수 없습니다."));
 
+        /*
+        잠시 부서 테스트용 나중에 주석 해제해야 함. 밑에 부서 객체 생성 지워야 함.
         Department department = departmentRepository.findById(dto.getDepartmentId())
-                .orElseThrow(() -> new DepartmentNotFoundException("부서를 찾을 수 없습니다."));
+                .orElseThrow(() -> new DepartmentNotFoundException("부서를 찾을 수 없습니다.")); */
+        Department department = new Department(1L, "마케팅팀", null);
 
         Post post = dto.toEntity(writer, department);
 
         Post savedPost = postRepository.save(post);
 
         return PostResponseDto.from(savedPost);
+    }
+
+    @Transactional
+    public void deletePost(Long postId, UserDetailsImpl userDetails) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException("게시글을 찾을 수 없습니다."));
+
+        User currentUser = userDetails.getUser();
+        boolean isAdmin = currentUser.isAdmin();
+
+        if (!isAdmin && !post.getWriter().getId().equals(currentUser.getId())) {
+            throw new UnauthorizedException("삭제 권한이 없습니다.");
+        }
+
+        postRepository.delete(post);
     }
 }


### PR DESCRIPTION
## 🪺 Summary
UpfitApplication 통과

## 🌱 Issue Number
- #14 


## 🙏 To Reviewers
**주요 변경사항:**
- PostController : /{postId}에 대한 DELETE 요청을 처리하는 엔드포인트 "deletePost"를 추가했습니다.
- PostServie : postId와 userDetails를 넘겨받아 권한을 확인한 뒤, 글 작성자와 관리자만 글을 삭제하는 "deletePost" 비즈니스 로직을 구현했습니다. **+ 테스트를 위해 writePost 로직에 글 작성 시 임의로 부서를 마케팅팀으로 설정하는 코드를 작성했습니다. (추후 삭제 요망)**
- DataLoader : 테스트용 부서 더미 데이터를 생성하기 위해 생성한 클래스입니다. 서버 실행 시, 자동으로 SQL문을 실행하여 몇 개의 부서 데이터를 데이터베이스에 생성합니다. (추후 삭제 요망)
- PostNotFoundException : 게시글을 찾지 못 했을 경우에 대한 예외를 추가했습니다.

---
**로컬 상 테스트 내용**
- 존재한 게시글에 대해 정상적으로 삭제가 진행되고 204 코드 반환이 되는 것을 확인했습니다.
- 존재하지 않는 게시글 번호에 대한 정상적인 예외 처리를 확인했습니다.
- 인가되지 않은 사용자에 대해 글 삭제가 거부되는 지는 테스트하지 못 했습니다.